### PR TITLE
Expressing restrictions on tag files and tag manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ Examples
    "Accept-Serialization":[
       "application/zip"
    ],
+   "Tag-Manifests-Required":[
+     "md5"
+   ],
+   "Tag-Files-Required":[
+      "DPN/dpnFirstNode.txt",
+      "DPN/dpnRegistry"
+   ],
    "Accept-BagIt-Version":[
       "0.96"
    ]

--- a/bagProfileBar.json
+++ b/bagProfileBar.json
@@ -75,7 +75,6 @@
      "md5"
    ],
    "Tag-Files-Required":[
-     "DPN",
      "DPN/dpnFirstNode.txt",
      "DPN/dpnRegistry"
    ],


### PR DESCRIPTION
According to the BagIt spec, implementers MAY put whatever they want in local tag files. They SHOULD register their local files in a tag manfiest (but this manifest file is optional).

Currently, the profile spec doesn't provide a way to indicate whether a tag manifest is required, nor does it provide a way to indicate which tag files are required.  I propose that we add the following high-level keys to the profile spec to fix these deficiencies:

`Tag-Manifests-Required`: LIST

Each manifest file in LIST is required. // <- works same as Manifests-Required

`Tag-Files-Required`: LIST

A list of tag files that must be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the BagIt Spec, these tag files need not be listed in tag manifest files.

Anybody got any thoughts on this? It should be simple to test for these conditions in a validator.
