### PR TITLE
Clarify that version numbers must be strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The following fields make up a BagIt profile. Each field is a top-level JSON key
 
 7. `Accept-BagIt-Version`: LIST
 
-	A list of BagIt version numbers that will be accepted. At least one version is required.
+	A list of BagIt version numbers that will be accepted. At least one version number is required. All version numbers MUST be UTF-8 encoded strings.
 
 8. `Tag-Manifests-Required`: LIST
 


### PR DESCRIPTION
The `Accept-BagIt-Version` field must contain a list of strings.

Because `0.96`, `0.97` or `1.0` (but not `1.1.0` obviously) are also valid floats in JSON, I did not realize we had a weird error in our profile for bags with (correctly typed) string `BagIt-Version` fields.