### PR TITLE
Profile version

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,20 +93,20 @@ the complete filename), e.g. `["sha1", "md5"]`.
 
 9. `Tag-Files-Required`: LIST
 
-  A list of a tag files that must be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](http://tools.ietf.org/html/draft-kunze-bagit-08), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
+  A list of a tag files that must be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](https://tools.ietf.org/html/rfc8493), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
 
   Every file in `Tag-Files-Required` must also be present in `Tag-Files-Allowed`.
 
 10. `Tag-Files-Allowed`: LIST
 
-  A list of tag files that may be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](http://tools.ietf.org/html/draft-kunze-bagit-08), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
+  A list of tag files that may be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](https://tools.ietf.org/html/rfc8493), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
 
   At least all the tag files listed in `Tag-Files-Required` must be in included in `Tag-Files-Allowed`.
 
 Examples
 ---
 
-[bagProfileFoo.json](https://raw.github.com/ruebot/bagit-profiles/master/bagProfileFoo.json)
+[bagProfileFoo.json](https://raw.github.com/bagit-profiles/bagit-profiles/master/bagProfileFoo.json)
 
 ```json
 {
@@ -148,7 +148,7 @@ Examples
 }
 ```
 
-[bagProfileBar.json](https://raw.github.com/ruebot/bagit-profiles/master/bagProfileBar.json)
+[bagProfileBar.json](https://raw.github.com/bagit-profiles/bagit-profiles/master/bagProfileBar.json)
 
 ```json
 {
@@ -244,7 +244,7 @@ Examples
 * ~~Request feedback from BagIt implementer community, initially in the Digital Curation Google Group.~~
 * ~~Write code to confirm proof-of-concept use cases.~~
 * ~~Formalize specification.~~ (Version 1.0 2013-05-19)
-* Write standard libraries to assist in profile validation. ~~([Python](https://github.com/ruebot/bagit-profiles-validator) done)~~
+* Write standard libraries to assist in profile validation. ~~([Python](https://github.com/bagit-profiles/bagit-profiles-validator) done)~~
 * Establish a public registry of BagIt profiles for common uses, such as ingestion of content into repository platforms.
 
 ### License

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ the complete filename), e.g. `["sha1", "md5"]`.
 
   A list of a tag files that must be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](http://tools.ietf.org/html/draft-kunze-bagit-08), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
 
+  Every file in `Tag-Files-Required` must also be present in `Tag-Files-Allowed`.
+
+10. `Tag-Files-Allowed`: LIST
+
+  A list of tag files that may be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](http://tools.ietf.org/html/draft-kunze-bagit-08), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
+
+  At least all the tag files listed in `Tag-Files-Required` must be in included in `Tag-Files-Allowed`.
+
 Examples
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BagIt Profiles Specification
 
 Status of this specification
 ---
-Current version: 1.1.0 (2017-05-10). Maintained by Mark Jordan and Nick Ruest. 
+Current version: 1.2.0 (2018-12-03). Maintained by Mark Jordan and Nick Ruest. 
 
 Original draft created by members of the Access 2012 Hackfest group: Meghan Currie, Krista Godfrey, Mark Jordan, Nick Ruest, William Wueppelmann, and Dan Chudnov.
 
@@ -55,7 +55,26 @@ The following fields make up a BagIt profile. Each field is a top-level JSON key
 
 1. `BagIt-Profile-Info`:
 
-	A list of tags that describes the profile itself. The following tags are required in this section: "Source-Organization", "External-Description", "Version", and "BagIt-Profile-Identifier". The first two of these tags are taken from the reserved tags defined in the BagIt spec. The value of "Version" contains the version of the profile; the value of "BagIt-Profile-Identifier" is the URI where the profile file is available, and will have the same value as the "BagIt-Profile-Identifier" tag in bag-info.txt (see below). Inclusion of "Contact-Name," "Contact-Phone" and "Contact-Email," as defined in the BagIt spec, is not required but is encouraged.
+A list of tags that describes the profile itself. The following tags are
+required in this section: `Source-Organization`, `External-Description`,
+`Version`, and `BagIt-Profile-Identifier`. Starting with version [`v1.2.0`],
+`BagIt-Profile-Version` is also required.
+
+The `Source-Organization` and `External-Description` tags are taken from the
+[reserved tags defined in the BagIt spec](https://tools.ietf.org/html/rfc8493#page-10).
+
+The value of `Version` contains the version of the profile; the value of
+`BagIt-Profile-Identifier` is the URI where the profile file is available, and
+will have the same value as the `BagIt-Profile-Identifier` tag in bag-info.txt
+(see below).
+
+The value of `BagIt-Profile-Version` contains the version of this specification the
+profile.conforms to. Since the tag was introduced after version [`v1.1.0`], any
+profile not explicitly defining `BagIt-Profile-Version` should be treated as
+conforming to version [`1.1.0`] of this specification.
+
+Inclusion of `Contact-Name,` `Contact-Phone` and `Contact-Email,`
+as [defined in the BagIt spec](https://tools.ietf.org/html/rfc8493#page-10), is not required but is encouraged.
 
 2. `Bag-Info`:
 
@@ -98,6 +117,8 @@ the complete filename), e.g. `["sha1", "md5"]`.
   Every file in `Tag-Files-Required` must also be present in `Tag-Files-Allowed`.
 
 10. `Tag-Files-Allowed`: LIST
+
+*(Added in [`v1.2.0`])*
 
   A list of tag files that may be included in a conformant Bag. Entries are either full path names relative to the bag base directory or path name patterns in which asterisks can represent zero or more characters (c.f. [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)).
 
@@ -263,3 +284,6 @@ Examples
 ### License
 
 ![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png "CC0")
+
+[`v1.1.0`]: https://github.com/bagit-profiles/bagit-profiles/tree/1.1.0
+[`v1.2.0`]: https://github.com/bagit-profiles/bagit-profiles/tree/1.2.0

--- a/README.md
+++ b/README.md
@@ -93,13 +93,17 @@ the complete filename), e.g. `["sha1", "md5"]`.
 
 9. `Tag-Files-Required`: LIST
 
-  A list of a tag files that must be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](https://tools.ietf.org/html/rfc8493), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
+  A list of a tag files that must be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](https://tools.ietf.org/html/rfc8493), these tag files need not be listed in tag manifest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
 
   Every file in `Tag-Files-Required` must also be present in `Tag-Files-Allowed`.
 
 10. `Tag-Files-Allowed`: LIST
 
-  A list of tag files that may be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](https://tools.ietf.org/html/rfc8493), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
+  A list of tag files that may be included in a conformant Bag. Entries are either full path names relative to the bag base directory or path name patterns in which asterisks can represent zero or more characters (c.f. [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)).
+
+  If `Tag-Files-Allowed` is not provided, its value is assumed to be `['*']`, i.e. all tag files are allowed.
+
+As per the [BagIt Spec](https://tools.ietf.org/html/rfc8493), these tag files need not be listed in tag manifest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
 
   At least all the tag files listed in `Tag-Files-Required` must be in included in `Tag-Files-Allowed`.
 
@@ -108,6 +112,7 @@ Examples
 
 [bagProfileFoo.json](https://raw.github.com/bagit-profiles/bagit-profiles/master/bagProfileFoo.json)
 
+<!-- BEGIN-EVAL -w '```json' '```' -- cat ./bagProfileFoo.json -->
 ```json
 {
    "BagIt-Profile-Info":{
@@ -148,11 +153,14 @@ Examples
 }
 ```
 
+<!-- END-EVAL -->
+
 [bagProfileBar.json](https://raw.github.com/bagit-profiles/bagit-profiles/master/bagProfileBar.json)
 
+<!-- BEGIN-EVAL -w '```json' '```' -- cat ./bagProfileBar.json  -->
 ```json
 {
-     "BagIt-Profile-Info":{
+   "BagIt-Profile-Info":{
       "BagIt-Profile-Identifier":"http://canadiana.org/standards/bagit/tdr_ingest.json",
       "Source-Organization":"Candiana.org",
       "Contact-Name":"William Wueppelmann",
@@ -227,15 +235,20 @@ Examples
    "Tag-Manifests-Required":[
      "md5"
    ],
+   "Tag-Files-Allowed":[
+     "DPN/*"
+   ],
    "Tag-Files-Required":[
-      "DPN/dpnFirstNode.txt",
-      "DPN/dpnRegistry"
+     "DPN/dpnFirstNode.txt",
+     "DPN/dpnRegistry"
    ],
    "Accept-BagIt-Version":[
       "0.96"
    ]
 }
 ```
+
+<!-- END-EVAL -->
 
 @todo
 ---

--- a/bagProfileBar.json
+++ b/bagProfileBar.json
@@ -74,6 +74,9 @@
    "Tag-Manifests-Required":[
      "md5"
    ],
+   "Tag-Files-Allowed":[
+     "DPN/*"
+   ],
    "Tag-Files-Required":[
      "DPN/dpnFirstNode.txt",
      "DPN/dpnRegistry"


### PR DESCRIPTION
Adds a field `BagIt-Profile-Version` to the `BagIt-Profile-Info` tag set that declares the profile spec version this profile is compliant to.

See https://github.com/bagit-profiles/bagit-profiles/pull/14#issuecomment-438657348 and following comments for background.