### PR TITLE
set BagIt-Profile-Version for samples

### DIFF
--- a/bagProfileBar.json
+++ b/bagProfileBar.json
@@ -1,6 +1,7 @@
 {
    "BagIt-Profile-Info":{
       "BagIt-Profile-Identifier":"http://canadiana.org/standards/bagit/tdr_ingest.json",
+      "BagIt-Profile-Version": "1.2.0",
       "Source-Organization":"Candiana.org",
       "Contact-Name":"William Wueppelmann",
       "Contact-Email":"tdr@canadiana.com",

--- a/bagProfileFoo.json
+++ b/bagProfileFoo.json
@@ -1,6 +1,7 @@
 {
    "BagIt-Profile-Info":{
       "BagIt-Profile-Identifier":"http://www.library.yale.edu/mssa/bagitprofiles/disk_images.json",
+      "BagIt-Profile-Version": "1.1.0",
       "Source-Organization":"Yale University",
       "Contact-Name":"Mark Matienzo",
       "External-Description":"BagIt profile for packaging disk images",


### PR DESCRIPTION
This got lost in merging, sets [BagIt-Profile-Version](#16) for the bundled samples.

Setting the version is required for [python validator](bagit-profiles-validator#17) unit tests to pass.