### PR TITLE
APTrust proposed changes to BagIt profiles v1.2.0 -> 1.3.0

### DIFF
--- a/aptrust-changes/README.md
+++ b/aptrust-changes/README.md
@@ -1,0 +1,195 @@
+# APTrust Proposed BagIt Profile Changes
+
+APTrust has been using a modified version of BagIt profiles as part of its open source [DART](https://github.com/APTrust/dart) software. Among other things, DART can both build and validate bags according to a BagIt profile.
+
+As part of its test suite, DART includes profiles from APTrust and the now defunct DPN. Each of these profiles includes a custom tag file with a number of required tags.
+
+The existing BagIt profiles in this repository cannot describe valid APTrust and DPN bags because APTrust requires a tag file called aptrust-info.txt, which must contain a specific set of tags, and DPN required a file called dpn-tags/dpn-info.txt whose tags also had to comply with a defined set of requirements.
+
+## Limitations of Tag Definitions in BagIt-Profiles v1.2.0
+
+BagIt-Profiles v1.2.0 allows users to specify which tags should be present in the bag-info.txt file, whether they're required, and which values are allowed. For example:
+
+```json
+   "Bag-Info":{
+      "Source-Organization":{
+         "required":true,
+         "values":[
+            "Simon Fraser University",
+            "York University"
+         ]
+      },
+      "Contact-Name":{
+         "required":true,
+         "values":[
+            "Mark Jordan",
+            "Nick Ruest"
+         ]
+      },
+      "Contact-Phone":{
+         "required":false
+      }
+```
+
+v1.2.0 also allows users to specify which tag files are required, like so:
+
+```json
+   "Tag-Files-Required":[
+     "DPN/dpnFirstNode.txt",
+     "DPN/dpnRegistry"
+   ]
+```
+
+The spec does not allow users to specify which specific tags are required in additional files like `aptrust-info.txt` and `dpn/dpn-tags.txt`.
+
+It may be possible to define additional fields in the profile like so to add these definitions:
+
+```json
+   "APTrust-Info":{
+      "Access":{
+         "required":true,
+         "values":[
+            "Institution",
+            "Consortia",
+            "Restricted"
+         ]
+      },
+      "Title":{
+         "required":true
+      },
+```
+
+This approach presents two problems.
+
+1. First, in order to collect a list of all tag definitions, the software that creates or validates the bag must scan through all the keys of BagIt profile JSON structure and look for keys that don't match known names like `Manifests-Required`, `Allow-Fetch.txt`, etc. Then it must assume these keys describe tag files, and the values describe tags expected to be in those files.
+
+2. Second, the key names in the JSON structure don't necessarily match the tag file names. Bag-Info.txt and bag-info.txt are not the same thing on case-sensitive file systems.
+
+## Proposed Fix for Tag Definitions
+
+A single key in a BagIt profile called Tags can contain a list of all required tag files as well as definitions of the tags expected to be in them. For example:
+
+```json
+    "Tags":[
+        {
+            "tagFile": "bag-info.txt",
+            "tagName": "Source-Organization",
+            "required": true,
+            "help": "The name of the organization that produced this bag, or is responsible for its contents."
+        },
+        {
+            "tagFile": "aptrust-info.txt",
+            "tagName": "Title",
+            "required": true,
+            "help": "The title or name of that describes this bag's contents."
+        },
+        {
+            "tagFile": "aptrust-info.txt",
+            "tagName": "Access",
+            "required": true,
+            "values": [
+                "Consortia",
+                "Institution",
+                "Restricted"
+            ],
+            "help": "Access rights for this bag describe who can see that it exists in the repository."
+        }
+    ]
+```
+
+Bagging software and bag validators can scan a single list in the profile definition to get a list of all required tags in all required tag files. If a tag file contains a single required tag, the bagger/validator can assume the containing tag file is also required. `Tag-Files-Required` may then no longer require a separate definition.
+
+### A Note on the Help Attribute
+
+APTrust uses the help attribute of each tag definition to provide tooltips in its graphical bagging library. These tips help users understand what information is expected in a tag field.
+
+Members of the [Beyond the Repository](https://northwestern.app.box.com/s/3qu2qbkdx3aod6wj9jt6977p4byhpj3y) (BTR) project will soon be publishing a BagIt profile intended to be supported by all distributed digital preservation repositories (DDPs) in the US. They also want a new attribute similar to `help` in the tag defintions, though they are calling it `definition`. The name isn't as important as the presence of some inline documentation to help bag creators supply meaningful tag values.
+
+## Manifests-Allowed and Tag-Manifests-Allowed
+
+BagIt profiles v1.2.0 defines `Manifests-Required` and `Tag-Manifests-Required`.
+
+```json
+   "Manifests-Required":[
+      "md5"
+   ],
+   "Tag-Manifests-Required": [
+      "md5"
+   ]
+```
+
+However, APTrust currently supports, and BTR plans to support, `Manifests-Allowed` and `Tag-Manifests-Allowed`. In both cases, this is for the practical purpose of making it as easy as possible for depositors to push content to DDPs.
+
+APTrust found that some of its depositors' internal workflows already produced bags with md5 manifests, while others produced bags with sha256 manifests. To avoid making depositors redefine their internal workflows, APTrust started accepting bags with either md5 or sha256 manifests.
+
+Our profile definition looked like this:
+
+```json
+   "Manifests-Required":[],
+   "Tag-Manifests-Required": [],
+   "Manifests-Allowed":[
+      "md5",
+      "sha256"
+   ],
+   "Tag-Manifests-Allowed": [
+      "md5",
+      "sha256"
+   ]
+```
+
+Since the [BagIt specification](https://tools.ietf.org/html/rfc8493) says a bag must have a payload manifest, APTrust's validator does require a manifest, and will accept any one from the list.
+
+BTR plans a similar definition, in order to make the process of moving data from local repos into DDPs as simple as possible. Their definition will likely support all commonly-implemented digest algorithms, like this:
+
+```json
+   "Manifests-Allowed":[
+        "md5",
+        "sha1",
+        "sha224",
+        "sha256",
+        "sha384",
+        "sha512"
+   ],
+   "Tag-Manifests-Allowed": [
+        "md5",
+        "sha1",
+        "sha224",
+        "sha256",
+        "sha384",
+        "sha512"
+   ]
+```
+
+## Deserialization-Match-Required
+
+Finally, APTrust has one request related to validating serialized bags. We currently enforce a recommendation that was part of version 14 of the BagIt spec but was later dropped. [Section 4.2](https://tools.ietf.org/html/draft-kunze-bagit-14#page-11) of the old spec said:
+
+```
+The serialization SHOULD have the same name as the bag's base directory...
+```
+
+APTrust has always enforced a rule that these names MUST match. That is, if a tarred bag file is called `photos.tar`, it must untar to a single directory called `photos`.
+
+APTrust and other DDPs typically untar bags in a staging area during the ingest process. When the bag `photos.tar` bag untars to a directory called `photos`, we can be sure its contents will not overwrite or commingle with the contents of another bags being processed at the same time.
+
+When bags `photos.tar`, `audio.tar`, and `video.tar` all expand to directory called `bag_contents` and are all being ingested at the same time, we wind up with a mess.
+
+To prevent this, APTrust looks into serialized bags BEFORE deserializing them to ensure that the will expand into a directory with the same name. We reject bags that don't meet this rule.
+
+Although the recommendation in Section 4.2 was dropped from the official BagIt spec, we would like BagIt profiles to provide a way to specify whether a valid bag must deserialize to an expected directory. This rule would only apply to serialized bags, and can default to false.
+
+It has practical applications for DDPs and can vastly simplify the ingest process and the maintenance of the DDPs staging area. APTrust is not the only DDP to use a staging area for bag validation. Chronopolis, Texas Digital Library, and Hathi Trust also used staging areas when they acted as DPN nodes, and DDPs will likely continue to use them in the future.
+
+## BTR and APTrust Change Requests
+
+The BTR team will be submitting its comments and change requests separately in the coming weeks. Nothing in the BTR requests contradicts anything in the APTrust requests. The only difference so far is the name of the `help/description` attribute, and APTrust is flexible on that.
+
+## Included Sample Profiles
+
+The JSON files in this directory show sample BagIt profiles for APTrust and DPN that conform to the changes proposed above.
+
+Note that, for the time being, these samples go against the BagIt profile rule of not defining what's expected in the bagit.txt file. These profiles include ALL tags expected to be found in the bag.
+
+Including bagit.txt in the `Tags` list simplifies the work of the bagger and the validator by including all requirements in a single place.
+
+The examples also include a `Default-Value` attribute in tag definitions. DART uses this internally when creating bags. APTrust is not asking for this to be part of a future BagIt profile spec.

--- a/aptrust-changes/aptrust-bagit-profile.json
+++ b/aptrust-changes/aptrust-bagit-profile.json
@@ -1,6 +1,7 @@
     {
         "Accept-BagIt-Version": [
-            "0.97", "1.0"
+            "0.97",
+            "1.0"
         ],
         "Accept-Serialization": [
             "application/tar"
@@ -8,7 +9,7 @@
         "Allow-Fetch.txt": false,
         "BagIt-Profile-Info": {
             "BagIt-Profile-Identifier": "https://wiki.aptrust.org/xxxx.json",
-            "BagIt-Profile-Version": "x.x.x",
+            "BagIt-Profile-Version": "1.3.0",
             "Contact-Email": "support@aptrust.org",
             "Contact-Name": "A. Diamond",
             "External-Description": "Sample BagIt profile for ingesting content into APTrust.",
@@ -25,7 +26,7 @@
 			"sha224",
         	"sha256",
         	"sha384",
-        	"sha512"        
+        	"sha512"
         ],
         "Tag-Manifests-Allowed": [
         	"md5",
@@ -41,7 +42,8 @@
                 "tagName": "BagIt-Version",
                 "required": true,
                 "values": [
-                    "0.97", "1.0"
+                    "0.97",
+                    "1.0"
                 ],
                 "help": "Which version of the BagIt specification describes this bag's format?"
             },
@@ -145,4 +147,3 @@
             }
         ]
     }
-

--- a/aptrust-changes/aptrust-bagit-profile.json
+++ b/aptrust-changes/aptrust-bagit-profile.json
@@ -1,0 +1,148 @@
+    {
+        "Accept-BagIt-Version": [
+            "0.97", "1.0"
+        ],
+        "Accept-Serialization": [
+            "application/tar"
+        ],
+        "Allow-Fetch.txt": false,
+        "BagIt-Profile-Info": {
+            "BagIt-Profile-Identifier": "https://wiki.aptrust.org/xxxx.json",
+            "BagIt-Profile-Version": "x.x.x",
+            "Contact-Email": "support@aptrust.org",
+            "Contact-Name": "A. Diamond",
+            "External-Description": "Sample BagIt profile for ingesting content into APTrust.",
+            "Source-Organization": "aptrust.org",
+            "Version": "2.2"
+        },
+        "Serialization": "required",
+        "Deserialization-Match-Required": true,
+        "Manifests-Required": [],
+        "Tag-Manifests-Required": [],
+        "Manifests-Allowed": [
+        	"md5",
+        	"sha1",
+			"sha224",
+        	"sha256",
+        	"sha384",
+        	"sha512"        
+        ],
+        "Tag-Manifests-Allowed": [
+        	"md5",
+        	"sha1",
+			"sha224",
+        	"sha256",
+        	"sha384",
+        	"sha512"
+        ],
+        "Tags": [
+            {
+                "tagFile": "bagit.txt",
+                "tagName": "BagIt-Version",
+                "required": true,
+                "values": [
+                    "0.97", "1.0"
+                ],
+                "help": "Which version of the BagIt specification describes this bag's format?"
+            },
+            {
+                "tagFile": "bagit.txt",
+                "tagName": "Tag-File-Character-Encoding",
+                "required": true,
+                "values": [
+                    "UTF-8"
+                ],
+                "defaultValue": "UTF-8",
+                "help": "How are this bag's plain-text tag files encoded? (Hint: usually UTF-8)"
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Source-Organization",
+                "required": true,
+                "values": [],
+                "help": "The name of the organization that produced this bag, or is responsible for its contents."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bag-Count",
+                "required": false,
+                "help": "The number of bags that make up this object. Set this only if you are packaging a single object into multiple bags. See https://wiki.aptrust.org/Bagging_specifications for info on naming multi-part APTrust bags."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bagging-Date",
+                "required": false,
+                "help": "The date this bag was created. The bagging software should set this automatically."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bagging-Software",
+                "required": false,
+                "help": "The name of the software that created this bag. The bagging software should set this automatically."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bag-Group-Identifier",
+                "required": false,
+                "help": "Identifies the logical group or collection to which a bag belongs. Several bags may share the same Bag-Group-Identifier to indicate that they are part of the same logical grouping."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Internal-Sender-Description",
+                "required": false,
+                "help": "A description of the bag's contents for the sender's internal use. This description will appear in the APTrust registry if you do not set the Description tag in the aptrust-info.txt file."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Internal-Sender-Identifier",
+                "required": false,
+                "help": "A unique identifier for this bag inside your organization."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Payload-Oxum",
+                "required": false,
+                "help": "The number of files and bytes in this bag's payload. This should be calculated and set by the bagging software."
+            },
+            {
+                "tagFile": "aptrust-info.txt",
+                "tagName": "Title",
+                "required": true,
+                "help": "The title or name of that describes this bag's contents."
+            },
+            {
+                "tagFile": "aptrust-info.txt",
+                "tagName": "Access",
+                "required": true,
+                "values": [
+                    "Consortia",
+                    "Institution",
+                    "Restricted"
+                ],
+                "help": "Access rights for this bag describe who can see that it exists in the repository."
+            },
+            {
+                "tagFile": "aptrust-info.txt",
+                "tagName": "Description",
+                "required": false,
+                "help": "The description of the bag that you want to appear in the APTrust registry."
+            },
+            {
+                "tagFile": "aptrust-info.txt",
+                "tagName": "Storage-Option",
+                "required": true,
+                "values": [
+                    "Standard",
+                    "Glacier-OH",
+                    "Glacier-OR",
+                    "Glacier-VA",
+                    "Glacier-Deep-OH",
+                    "Glacier-Deep-OR",
+                    "Glacier-Deep-VA"
+                ],
+                "defaultValue": "Standard",
+                "help": "How do you want this bag to be stored in APTrust? Standard = S3/Virginia + Glacier/Oregon. Glacier-OH = Glacier-only storage in Ohio. Glacier-OR = Glacier-only storage in Oregon. Glacier-VA = Glacier-only storage in Virginia. Standard storage includes regular 90-day fixity checks. Glacier-only storage is less expensive but excludes fixity checks. File in Glacier-only storage may take up to 24 hours longer to restore and excessive Glacier retrieval may incur additional fees."
+            }
+        ]
+    }
+

--- a/aptrust-changes/dpn-bagit-profile.json
+++ b/aptrust-changes/dpn-bagit-profile.json
@@ -1,0 +1,186 @@
+{
+        "Accept-BagIt-Version": [
+            "0.97", "1.0"
+        ],
+        "Accept-Serialization": [
+            "application/tar"
+        ],
+        "Allow-Fetch.txt": false,
+        "Deserialization-Match-Required": true,
+        "BagIt-Profile-Info": {
+            "BagIt-Profile-Identifier": "https://wiki.aptrust.org/dpnxxx.json",
+            "BagIt-Profile-Version": "x.x.x",
+            "Contact-Email": "support@dpn.org",
+            "Contact-Name": "A. Diamond",
+            "External-Description": "BagIt profile for ingesting content into DPN.",
+            "Source-Organization": "dpn.org",
+            "Version": "2.1"
+        },
+        "Manifests-Required": [
+            "sha256"
+        ],
+        "Serialization": "required",
+		"Deserialization-Match-Required": true,
+        "Tag-Manifests-Required": [
+            "sha256"
+        ],
+        "Tags": [
+            {
+                "tagFile": "bagit.txt",
+                "tagName": "BagIt-Version",
+                "required": true,
+                "values": [
+                    "0.97", "1.0"
+                ],
+                "defaultValue": "0.97",
+                "help": "Which version of the BagIt specification describes this bag's format?"
+            },
+            {
+                "tagFile": "bagit.txt",
+                "tagName": "Tag-File-Character-Encoding",
+                "required": true,
+                "values": [
+                    "UTF-8"
+                ],
+                "defaultValue": "UTF-8",
+                "help": "How are this bag's plain-text tag files encoded? (Hint: usually UTF-8)"
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Source-Organization",
+                "required": true,
+                "values": [],
+                "help": "The name of the organization that produced this bag, or is responsible for its contents."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Organization-Address",
+                "required": true,
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Contact-Name",
+                "required": true,
+                "values": [],
+                "help": "The street address of the source organization."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Contact-Phone",
+                "required": true,
+                "values": [],
+                "help": "The phone number of the bagging/archiving contact in the source organization."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Contact-Email",
+                "required": true,
+                "help": "The email address of the bagging/archiving contact in the source organization."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bagging-Date",
+                "required": true,
+                "help": "The date this bag was created. The bagging software should set this automatically."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bagging-Software",
+                "required": false,
+                "help": "The name of the software that created this bag. The bagging software should set this automatically."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bag-Size",
+                "required": true,
+                "help": "The approximate size of the bag's payload, in human-readable format. E.g. 33MB or 268GB."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bag-Group-Identifier",
+                "required": true,
+                "help": "An identifier that marks this bag as part of a single collection or a related group of items that has been packaged into several bags."
+            },
+            {
+                "tagFile": "bag-info.txt",
+                "tagName": "Bag-Count",
+                "required": true,
+                "help": "Two numbers separated by \"of\", in particular, \"N of T\", where T is the total number of bags in a group of bags and N is the ordinal number within the group; if T is not known, specify it as \"?\" (question mark).  Examples: 1 of 2, 4 of 4, 3 of ?, 89 of 145."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "DPN-Object-ID",
+                "required": true,
+                "values": [],
+                "help": "The bag's unique identifier, which is a version 4 UUID that must match the bag name. The system should set this automatically."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Local-ID",
+                "required": true,
+                "values": [],
+                "help": "You're local name or unique identifier for this bag."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Ingest-Node-Name",
+                "required": true,
+                "help": "The name of the DPN node that ingests this bag."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Ingest-Node-Address",
+                "required": true,
+                "help": "The street address of the node that ingests this bag."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Ingest-Node-Contact-Name",
+                "required": true,
+                "help": "The name of the technical or administrative contact at the ingest node."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Ingest-Node-Contact-Email",
+                "required": true,
+                "help": "The email address of the technical or administrative contact at the ingest node."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Version-Number",
+                "required": true,
+                "help": "The version number of this bag. Until DPN fully supports bag versioning, this should be set to 1."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "First-Version-Object-ID",
+                "required": true,
+                "values": [],
+                "help": "The unique identifier of the first version of this bag. Until DPN fully supports versionion, this should be set automatically by the bagging software to match the bag name and DPN-Object-ID."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Interpretive-Object-ID",
+                "required": true,
+                "values": [],
+                "help": "The unique identifier of the DPN bag that contains information about how to brighten this bag. Because brightening bags are not yet implemented, this should be left blank."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Rights-Object-ID",
+                "required": true,
+                "help": "The unique identifier of the DPN bag that contains information about legal rights governing this bag's content. Because rights bags are not yet implemented, this should be left blank."
+            },
+            {
+                "tagFile": "dpn-tags/dpn-info.txt",
+                "tagName": "Bag-Type",
+                "required": true,
+                "values": [
+                    "data",
+                    "interpretive",
+                    "rights"
+                ],
+                "help": "The type of this DPN bag. This should be set to 'data', since other bag types are not yet implemented."
+            }
+        ]
+    }

--- a/aptrust-changes/dpn-bagit-profile.json
+++ b/aptrust-changes/dpn-bagit-profile.json
@@ -1,6 +1,7 @@
 {
         "Accept-BagIt-Version": [
-            "0.97", "1.0"
+            "0.97",
+            "1.0"
         ],
         "Accept-Serialization": [
             "application/tar"
@@ -9,7 +10,7 @@
         "Deserialization-Match-Required": true,
         "BagIt-Profile-Info": {
             "BagIt-Profile-Identifier": "https://wiki.aptrust.org/dpnxxx.json",
-            "BagIt-Profile-Version": "x.x.x",
+            "BagIt-Profile-Version": "1.3.0",
             "Contact-Email": "support@dpn.org",
             "Contact-Name": "A. Diamond",
             "External-Description": "BagIt profile for ingesting content into DPN.",
@@ -30,7 +31,8 @@
                 "tagName": "BagIt-Version",
                 "required": true,
                 "values": [
-                    "0.97", "1.0"
+                    "0.97",
+                    "1.0"
                 ],
                 "defaultValue": "0.97",
                 "help": "Which version of the BagIt specification describes this bag's format?"
@@ -180,6 +182,7 @@
                     "interpretive",
                     "rights"
                 ],
+                "defaultValue": "data",
                 "help": "The type of this DPN bag. This should be set to 'data', since other bag types are not yet implemented."
             }
         ]


### PR DESCRIPTION
APTrust proposes a number of changes to the BagIt profile structure to provide richer description of bags, to simplify and clarify the bagging process for bag creators, and to help organizations ingesting bags. 

The README file in the aptrust-changes folder describes limitations in the current profile structure and proposed solutions. The folder also includes two sample profiles.

I kept changes separate from the existing code/readme. Let me know if you want me to change the actual json & readme. I'm not really sure how to request a pull on a non-code repo.